### PR TITLE
fix build under -O0

### DIFF
--- a/Download/peermodel.h
+++ b/Download/peermodel.h
@@ -10,7 +10,7 @@ public:
     PeerModel(QObject *parent = nullptr);
     void setPeers(const QJsonArray &statusObj, int numPieces);
     void clear();
-    static const int ProgressCluster = 1024;
+    static constexpr const int ProgressCluster = 1024;
     struct PeerInfo
     {
         QString client, ip;


### PR DESCRIPTION
目前的master分支，如果关闭优化，链接时会发生错误（提示找不到符号）。这个pr可以解决这个问题。原因可以参考[这里](https://en.cppreference.com/w/cpp/language/static#:~:text=If%20a%20const%20non%2Dinline%20(since%20C%2B%2B17)%20static%20data%20member%20or%20a%20constexpr%20static%20data%20member%20(since%20C%2B%2B11)(until%20C%2B%2B17)%20is%20odr%2Dused%2C%20a%20definition%20at%20namespace%20scope%20is%20still%20required)

代码中类似的“隐患”还有一些，例如[这里](https://github.com/KikoPlayProject/KikoPlay/blob/ec4537001f1b08a058f3369c994f014d5f9e5fc8/globalobjects.h#L47)，一旦被所谓“odr-used”，就会出错。当然也可能被优化掉而不出错，就像目前的 master 分支一样。

个人的习惯是，除非 constexpr，否则一定会在类外再定义一遍，初始化也会放在类外。对于 header only的写法，就写到头文件里并用 inline 修饰；对于像这样定义都写到cpp文件里的写法，就放到对应的cpp文件里。供参考。