### PR TITLE
Optimize build scripts and fix build errors under linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,6 @@ cmake_minimum_required(VERSION 3.16.0)
 
 # If QT is installed in your system, it can be FALSE
 option(USE_VCPKG_QT "Use vcpkg to add QT dependency" ON)
-# Set default overridable parameters for "/usr/share"
-set(CMAKE_INSTALL_SHAREDIR "/usr/share" CACHE STRING "The default share path")
 
 if (USE_VCPKG_QT)
     list(APPEND VCPKG_MANIFEST_FEATURES "qt-dependencies")
@@ -100,6 +98,11 @@ if (WIN32)
 endif()
 
 if (UNIX)
+    # Set default overridable parameters for "/usr/share"
+    set(CMAKE_INSTALL_SHAREDIR "/usr/share" CACHE STRING "The default share path")
+    # Set default unix data option
+    option(CONFIG_UNIX_DATA "Use unix data path" ON)
+
     include(FindPkgConfig)
     pkg_check_modules(mpv QUIET mpv)
 
@@ -111,6 +114,11 @@ if (UNIX)
     PRIVATE
         ${mpv_LIBRARIES}
     )
+
+    if (CONFIG_UNIX_DATA)
+        message("CONFIG_UNIX_DATA = ON")
+        target_compile_definitions(${PROJECT_NAME} PRIVATE CONFIG_UNIX_DATA=1)
+    endif()
 
     install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
     install(FILES kikoplay.png kikoplay.xpm DESTINATION "${CMAKE_INSTALL_SHAREDIR}/pixmaps")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,176 +21,46 @@ find_package(Qt5 COMPONENTS Widgets Core Gui Network Concurrent Sql Svg REQUIRED
 find_package(ZLIB REQUIRED)
 add_subdirectory(Script/lua)
 
+function(include_sub_directories_recursively ROOT_DIR)
+    if (IS_DIRECTORY ${ROOT_DIR})
+        include_directories(${ROOT_DIR})
+    endif()
+
+    file(GLOB SUB_LIST RELATIVE ${ROOT_DIR} ${ROOT_DIR}/*)
+    foreach(SUB ${SUB_LIST})
+        if (IS_DIRECTORY ${ROOT_DIR}/${SUB})
+            include_sub_directories_recursively(${ROOT_DIR}/${SUB})
+        endif()
+    endforeach()
+endfunction()
+
+set (CMAKE_PROJECT_SEARCH_PATH
+    ${CMAKE_SOURCE_DIR}/Common
+    ${CMAKE_SOURCE_DIR}/Download
+    ${CMAKE_SOURCE_DIR}/LANServer
+    ${CMAKE_SOURCE_DIR}/MediaLibrary
+    ${CMAKE_SOURCE_DIR}/Play
+    ${CMAKE_SOURCE_DIR}/Script
+    ${CMAKE_SOURCE_DIR}/UI
+)
+
+foreach(SEARCH_PATH ${CMAKE_PROJECT_SEARCH_PATH})
+    include_sub_directories_recursively(${SEARCH_PATH})
+endforeach()
+
+file(READ "KikoPlay.pro" KIKOPLAY_PRO_CONTENTS)
+
+string(REGEX MATCHALL "[A-Za-z0-9_\\/]+\\.cpp" CMAKE_PROJECT_SOURCE_FILES "${KIKOPLAY_PRO_CONTENTS}")
+message("add sources: " "${CMAKE_PROJECT_SOURCE_FILES}")
+
 add_executable(${PROJECT_NAME}
-    Common/counter.cpp 
-    Common/logger.cpp 
-    Common/notifier.cpp 
-    Download/autodownloadmanager.cpp 
-    Download/peermodel.cpp 
-    Download/trackersubscriber.cpp 
-    LANServer/apihandler.cpp 
-    LANServer/dlna/dlnamediacontroller.cpp 
-    LANServer/dlna/dlnamediaitem.cpp 
-    LANServer/dlna/dlnamediaserver.cpp 
-    LANServer/dlna/upnp.cpp 
-    LANServer/dlna/upnpctrlpoint.cpp 
-    LANServer/dlna/upnpdevice.cpp 
-    LANServer/dlna/upnpservice.cpp 
-    LANServer/filehandler.cpp 
-    LANServer/httpserver/httpconnectionhandler.cpp 
-    LANServer/httpserver/httpconnectionhandlerpool.cpp 
-    LANServer/httpserver/httpcookie.cpp 
-    LANServer/httpserver/httpglobal.cpp 
-    LANServer/httpserver/httplistener.cpp 
-    LANServer/httpserver/httprequest.cpp 
-    LANServer/httpserver/httprequesthandler.cpp 
-    LANServer/httpserver/httpresponse.cpp 
-    LANServer/httpserver/httpsession.cpp 
-    LANServer/httpserver/httpsessionstore.cpp 
-    LANServer/httpserver/staticfilecontroller.cpp 
-    LANServer/router.cpp 
-    MediaLibrary/animeinfo.cpp 
-    MediaLibrary/animelistmodel.cpp 
-    MediaLibrary/animeprovider.cpp 
-    MediaLibrary/episodeitem.cpp 
-    MediaLibrary/tagnode.cpp 
-    Play/Danmu/Render/livedanmuitemdelegate.cpp 
-    Play/Danmu/Render/livedanmulistmodel.cpp 
-    Play/Danmu/danmuprovider.cpp 
-    Play/Danmu/eventanalyzer.cpp 
-    Play/Video/mpvpreview.cpp 
-    Play/Video/simpleplayer.cpp 
-    Script/bgmcalendarscript.cpp 
-    Script/danmuscript.cpp 
-    Script/libraryscript.cpp 
-    Script/luatablemodel.cpp 
-    Script/modules/lua_htmlparser.cpp 
-    Script/modules/lua_net.cpp 
-    Script/modules/lua_regex.cpp 
-    Script/modules/lua_util.cpp 
-    Script/modules/lua_xmlreader.cpp 
-    Script/modules/modulebase.cpp 
-    Script/playgroundscript.cpp 
-    Script/resourcescript.cpp 
-    Script/scriptbase.cpp 
-    Script/scriptmanager.cpp 
-    Script/scriptmodel.cpp 
-    Script/scriptsettingmodel.cpp 
-    UI/addpool.cpp 
-    UI/addrule.cpp 
-    UI/animebatchaction.cpp 
-    UI/animedetailinfopage.cpp 
-    UI/animeinfoeditor.cpp 
-    UI/animesearch.cpp 
-    UI/autodownloadwindow.cpp 
-    UI/charactereditor.cpp 
-    UI/danmulaunch.cpp 
-    UI/danmuview.cpp 
-    UI/dlnadiscover.cpp 
-    UI/gifcapture.cpp 
-    UI/inputdialog.cpp 
-    UI/logwindow.cpp 
-    UI/luatableviewer.cpp 
-    UI/scriptplayground.cpp 
-    UI/settings.cpp 
-    UI/settings/downloadpage.cpp 
-    UI/settings/lanserverpage.cpp 
-    UI/settings/mpvpage.cpp 
-    UI/settings/mpvshortcutpage.cpp 
-    UI/settings/scriptpage.cpp 
-    UI/settings/stylepage.cpp 
-    UI/settings/settingpage.cpp
-    UI/snippetcapture.cpp 
-    UI/stylemanager.cpp 
-    UI/widgets/backgroundfadewidget.cpp 
-    UI/widgets/backgroundwidget.cpp 
-    UI/widgets/clickslider.cpp 
-    UI/widgets/colorpicker.cpp 
-    UI/widgets/colorslider.cpp 
-    UI/widgets/danmustatiswidget.cpp 
-    UI/widgets/dialogtip.cpp 
-    UI/widgets/elidelineedit.cpp 
-    UI/widgets/fonticonbutton.cpp 
-    UI/widgets/loadingicon.cpp 
-    UI/widgets/optionslider.cpp 
-    UI/widgets/scriptsearchoptionpanel.cpp 
-    UI/widgets/smoothscrollbar.cpp 
-        main.cpp 
-    UI/mainwindow.cpp 
-    UI/framelesswindow.cpp 
-    Play/Danmu/Layouts/bottomlayout.cpp 
-    Play/Danmu/Layouts/rolllayout.cpp 
-    Play/Danmu/Layouts/toplayout.cpp 
-    Play/Danmu/danmupool.cpp 
-    globalobjects.cpp 
-    Play/Playlist/playlist.cpp 
-    Play/Video/mpvplayer.cpp 
-    UI/list.cpp 
-    UI/player.cpp 
-    UI/pooleditor.cpp 
-    UI/framelessdialog.cpp 
-    Play/Danmu/Provider/localprovider.cpp 
-    UI/adddanmu.cpp 
-    UI/matcheditor.cpp 
-    UI/selectepisode.cpp 
-    Play/Danmu/blocker.cpp 
-    UI/blockeditor.cpp 
-    UI/capture.cpp 
-    UI/mediainfo.cpp 
-    Play/Danmu/common.cpp 
-    UI/about.cpp 
-    Common/network.cpp 
-    Common/htmlparsersax.cpp 
-    MediaLibrary/animeitemdelegate.cpp 
-    UI/librarywindow.cpp 
-    MediaLibrary/episodesmodel.cpp 
-    Download/util.cpp 
-    Download/aria2jsonrpc.cpp 
-    UI/widgets/dirselectwidget.cpp 
-    Download/downloaditemdelegate.cpp 
-    Download/downloadmodel.cpp 
-    Download/torrent.cpp 
-    UI/downloadwindow.cpp 
-    UI/adduritask.cpp 
-    UI/selecttorrentfile.cpp 
-    UI/poolmanager.cpp 
-    UI/checkupdate.cpp 
-    Common/flowlayout.cpp 
-    UI/timelineedit.cpp 
-    LANServer/lanserver.cpp 
-    Play/Playlist/playlistitem.cpp 
-    Play/Playlist/playlistprivate.cpp 
-    Play/Danmu/Render/cacheworker.cpp 
-    Play/Danmu/Render/danmurender.cpp 
-    Play/Danmu/Manager/danmumanager.cpp 
-    Play/Danmu/Manager/nodeinfo.cpp 
-    Play/Danmu/Manager/managermodel.cpp 
-    MediaLibrary/animeworker.cpp 
-    MediaLibrary/animemodel.cpp 
-    MediaLibrary/labelmodel.cpp 
-    MediaLibrary/animefilterproxymodel.cpp 
-    MediaLibrary/labelitemdelegate.cpp 
-    Download/BgmList/bgmlist.cpp 
-    UI/bgmlistwindow.cpp 
-    UI/ressearchwindow.cpp 
-    Play/Danmu/Manager/pool.cpp 
-    MediaLibrary/capturelistmodel.cpp 
-    UI/captureview.cpp 
-    UI/tip.cpp
+    ${CMAKE_PROJECT_SOURCE_FILES}
     res.qrc
     kikoplay.rc
 )
 
 target_include_directories(${PROJECT_NAME}
-PRIVATE 
-    Common
-    Download
-    LANServer
-    MediaLibrary
-    Play
-    Script
-    UI
-    UI/settings/
+PRIVATE
     .
 )
 
@@ -240,4 +110,3 @@ if (UNIX)
         ${mpv_LIBRARIES}
     )
 endif()
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.16.0)
 
 # If QT is installed in your system, it can be FALSE
 option(USE_VCPKG_QT "Use vcpkg to add QT dependency" ON)
+# Set default overridable parameters for "/usr/share"
+set(CMAKE_INSTALL_SHAREDIR "/usr/share" CACHE STRING "The default share path")
 
 if (USE_VCPKG_QT)
     list(APPEND VCPKG_MANIFEST_FEATURES "qt-dependencies")
@@ -109,4 +111,9 @@ if (UNIX)
     PRIVATE
         ${mpv_LIBRARIES}
     )
+
+    install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+    install(FILES kikoplay.png kikoplay.xpm DESTINATION "${CMAKE_INSTALL_SHAREDIR}/pixmaps")
+    install(FILES kikoplay.desktop DESTINATION "${CMAKE_INSTALL_SHAREDIR}/applications")
+    install(DIRECTORY web DESTINATION "${CMAKE_INSTALL_SHAREDIR}/kikoplay")
 endif()

--- a/KikoPlay.pro
+++ b/KikoPlay.pro
@@ -39,11 +39,21 @@ CONFIG(debug, debug|release) {
 
 SOURCES += \
     Common/counter.cpp \
+    Common/flowlayout.cpp \
+    Common/htmlparsersax.cpp \
     Common/logger.cpp \
+    Common/network.cpp \
     Common/notifier.cpp \
+    Download/aria2jsonrpc.cpp \
     Download/autodownloadmanager.cpp \
+    Download/BgmList/bgmlist.cpp \
+    Download/downloaditemdelegate.cpp \
+    Download/downloadmodel.cpp \
     Download/peermodel.cpp \
+    Download/torrent.cpp \
     Download/trackersubscriber.cpp \
+    Download/util.cpp \
+    globalobjects.cpp \
     LANServer/apihandler.cpp \
     LANServer/dlna/dlnamediacontroller.cpp \
     LANServer/dlna/dlnamediaitem.cpp \
@@ -64,16 +74,43 @@ SOURCES += \
     LANServer/httpserver/httpsession.cpp \
     LANServer/httpserver/httpsessionstore.cpp \
     LANServer/httpserver/staticfilecontroller.cpp \
+    LANServer/lanserver.cpp \
     LANServer/router.cpp \
+    main.cpp \
+    MediaLibrary/animefilterproxymodel.cpp \
     MediaLibrary/animeinfo.cpp \
+    MediaLibrary/animeitemdelegate.cpp \
     MediaLibrary/animelistmodel.cpp \
+    MediaLibrary/animemodel.cpp \
     MediaLibrary/animeprovider.cpp \
+    MediaLibrary/animeworker.cpp \
+    MediaLibrary/capturelistmodel.cpp \
     MediaLibrary/episodeitem.cpp \
+    MediaLibrary/episodesmodel.cpp \
+    MediaLibrary/labelitemdelegate.cpp \
+    MediaLibrary/labelmodel.cpp \
     MediaLibrary/tagnode.cpp \
-    Play/Danmu/Render/livedanmuitemdelegate.cpp \
-    Play/Danmu/Render/livedanmulistmodel.cpp \
+    Play/Danmu/blocker.cpp \
+    Play/Danmu/common.cpp \
+    Play/Danmu/danmupool.cpp \
     Play/Danmu/danmuprovider.cpp \
     Play/Danmu/eventanalyzer.cpp \
+    Play/Danmu/Layouts/bottomlayout.cpp \
+    Play/Danmu/Layouts/rolllayout.cpp \
+    Play/Danmu/Layouts/toplayout.cpp \
+    Play/Danmu/Manager/danmumanager.cpp \
+    Play/Danmu/Manager/managermodel.cpp \
+    Play/Danmu/Manager/nodeinfo.cpp \
+    Play/Danmu/Manager/pool.cpp \
+    Play/Danmu/Provider/localprovider.cpp \
+    Play/Danmu/Render/cacheworker.cpp \
+    Play/Danmu/Render/danmurender.cpp \
+    Play/Danmu/Render/livedanmuitemdelegate.cpp \
+    Play/Danmu/Render/livedanmulistmodel.cpp \
+    Play/Playlist/playlist.cpp \
+    Play/Playlist/playlistitem.cpp \
+    Play/Playlist/playlistprivate.cpp \
+    Play/Video/mpvplayer.cpp \
     Play/Video/mpvpreview.cpp \
     Play/Video/simpleplayer.cpp \
     Script/bgmcalendarscript.cpp \
@@ -92,31 +129,56 @@ SOURCES += \
     Script/scriptmanager.cpp \
     Script/scriptmodel.cpp \
     Script/scriptsettingmodel.cpp \
+    UI/about.cpp \
+    UI/adddanmu.cpp \
     UI/addpool.cpp \
     UI/addrule.cpp \
+    UI/adduritask.cpp \
     UI/animebatchaction.cpp \
     UI/animedetailinfopage.cpp \
     UI/animeinfoeditor.cpp \
     UI/animesearch.cpp \
     UI/autodownloadwindow.cpp \
+    UI/bgmlistwindow.cpp \
+    UI/blockeditor.cpp \
+    UI/capture.cpp \
+    UI/captureview.cpp \
     UI/charactereditor.cpp \
+    UI/checkupdate.cpp \
     UI/danmulaunch.cpp \
     UI/danmuview.cpp \
     UI/dlnadiscover.cpp \
+    UI/downloadwindow.cpp \
+    UI/framelessdialog.cpp \
+    UI/framelesswindow.cpp \
     UI/gifcapture.cpp \
     UI/inputdialog.cpp \
+    UI/librarywindow.cpp \
+    UI/list.cpp \
     UI/logwindow.cpp \
     UI/luatableviewer.cpp \
+    UI/mainwindow.cpp \
+    UI/matcheditor.cpp \
+    UI/mediainfo.cpp \
+    UI/player.cpp \
+    UI/pooleditor.cpp \
+    UI/poolmanager.cpp \
+    UI/ressearchwindow.cpp \
     UI/scriptplayground.cpp \
+    UI/selectepisode.cpp \
+    UI/selecttorrentfile.cpp \
     UI/settings.cpp \
     UI/settings/downloadpage.cpp \
     UI/settings/lanserverpage.cpp \
     UI/settings/mpvpage.cpp \
     UI/settings/mpvshortcutpage.cpp \
     UI/settings/scriptpage.cpp \
+    UI/settings/settingpage.cpp \
     UI/settings/stylepage.cpp \
     UI/snippetcapture.cpp \
     UI/stylemanager.cpp \
+    UI/timelineedit.cpp \
+    UI/tip.cpp \
     UI/widgets/backgroundfadewidget.cpp \
     UI/widgets/backgroundwidget.cpp \
     UI/widgets/clickslider.cpp \
@@ -124,84 +186,36 @@ SOURCES += \
     UI/widgets/colorslider.cpp \
     UI/widgets/danmustatiswidget.cpp \
     UI/widgets/dialogtip.cpp \
+    UI/widgets/dirselectwidget.cpp \
     UI/widgets/elidelineedit.cpp \
     UI/widgets/fonticonbutton.cpp \
     UI/widgets/loadingicon.cpp \
     UI/widgets/optionslider.cpp \
     UI/widgets/scriptsearchoptionpanel.cpp \
-    UI/widgets/smoothscrollbar.cpp \
-        main.cpp \
-    UI/mainwindow.cpp \
-    UI/framelesswindow.cpp \
-    Play/Danmu/Layouts/bottomlayout.cpp \
-    Play/Danmu/Layouts/rolllayout.cpp \
-    Play/Danmu/Layouts/toplayout.cpp \
-    Play/Danmu/danmupool.cpp \
-    globalobjects.cpp \
-    Play/Playlist/playlist.cpp \
-    Play/Video/mpvplayer.cpp \
-    UI/list.cpp \
-    UI/player.cpp \
-    UI/pooleditor.cpp \
-    UI/framelessdialog.cpp \
-    Play/Danmu/Provider/localprovider.cpp \
-    UI/adddanmu.cpp \
-    UI/matcheditor.cpp \
-    UI/selectepisode.cpp \
-    Play/Danmu/blocker.cpp \
-    UI/blockeditor.cpp \
-    UI/capture.cpp \
-    UI/mediainfo.cpp \
-    Play/Danmu/common.cpp \
-    UI/about.cpp \
-    Common/network.cpp \
-    Common/htmlparsersax.cpp \
-    MediaLibrary/animeitemdelegate.cpp \
-    UI/librarywindow.cpp \
-    MediaLibrary/episodesmodel.cpp \
-    Download/util.cpp \
-    Download/aria2jsonrpc.cpp \
-    UI/widgets/dirselectwidget.cpp \
-    Download/downloaditemdelegate.cpp \
-    Download/downloadmodel.cpp \
-    Download/torrent.cpp \
-    UI/downloadwindow.cpp \
-    UI/adduritask.cpp \
-    UI/selecttorrentfile.cpp \
-    UI/poolmanager.cpp \
-    UI/checkupdate.cpp \
-    Common/flowlayout.cpp \
-    UI/timelineedit.cpp \
-    LANServer/lanserver.cpp \
-    Play/Playlist/playlistitem.cpp \
-    Play/Playlist/playlistprivate.cpp \
-    Play/Danmu/Render/cacheworker.cpp \
-    Play/Danmu/Render/danmurender.cpp \
-    Play/Danmu/Manager/danmumanager.cpp \
-    Play/Danmu/Manager/nodeinfo.cpp \
-    Play/Danmu/Manager/managermodel.cpp \
-    MediaLibrary/animeworker.cpp \
-    MediaLibrary/animemodel.cpp \
-    MediaLibrary/labelmodel.cpp \
-    MediaLibrary/animefilterproxymodel.cpp \
-    MediaLibrary/labelitemdelegate.cpp \
-    Download/BgmList/bgmlist.cpp \
-    UI/bgmlistwindow.cpp \
-    UI/ressearchwindow.cpp \
-    Play/Danmu/Manager/pool.cpp \
-    MediaLibrary/capturelistmodel.cpp \
-    UI/captureview.cpp \
-    UI/tip.cpp
+    UI/widgets/smoothscrollbar.cpp
 
 HEADERS += \
     Common/counter.h \
+    Common/flowlayout.h \
+    Common/htmlparsersax.h \
     Common/logger.h \
     Common/lrucache.h \
+    Common/network.h \
     Common/notifier.h \
+    Common/threadtask.h \
+    Common/zconf.h \
+    Common/zlib.h \
+    Download/aria2jsonrpc.h \
     Download/autodownloadmanager.h \
+    Download/BgmList/bgmlist.h \
+    Download/downloaditemdelegate.h \
+    Download/downloadmodel.h \
     Download/peerid.h \
     Download/peermodel.h \
+    Download/torrent.h \
     Download/trackersubscriber.h \
+    Download/util.h \
+    globalobjects.h \
     LANServer/apihandler.h \
     LANServer/dlna/dlnamediacontroller.h \
     LANServer/dlna/dlnamediaitem.h \
@@ -222,16 +236,44 @@ HEADERS += \
     LANServer/httpserver/httpsession.h \
     LANServer/httpserver/httpsessionstore.h \
     LANServer/httpserver/staticfilecontroller.h \
+    LANServer/lanserver.h \
     LANServer/router.h \
+    MediaLibrary/animefilterproxymodel.h \
+    MediaLibrary/animeinfo.h \
+    MediaLibrary/animeitemdelegate.h \
     MediaLibrary/animelistmodel.h \
+    MediaLibrary/animemodel.h \
     MediaLibrary/animeprovider.h \
+    MediaLibrary/animeworker.h \
+    MediaLibrary/capturelistmodel.h \
     MediaLibrary/episodeitem.h \
+    MediaLibrary/episodesmodel.h \
+    MediaLibrary/labelitemdelegate.h \
+    MediaLibrary/labelmodel.h \
     MediaLibrary/tagnode.h \
-    Play/Danmu/Render/livedanmuitemdelegate.h \
-    Play/Danmu/Render/livedanmulistmodel.h \
+    Play/Danmu/blocker.h \
+    Play/Danmu/common.h \
+    Play/Danmu/danmupool.h \
     Play/Danmu/danmuprovider.h \
     Play/Danmu/danmuviewmodel.h \
     Play/Danmu/eventanalyzer.h \
+    Play/Danmu/Layouts/bottomlayout.h \
+    Play/Danmu/Layouts/danmulayout.h \
+    Play/Danmu/Layouts/rolllayout.h \
+    Play/Danmu/Layouts/toplayout.h \
+    Play/Danmu/Manager/danmumanager.h \
+    Play/Danmu/Manager/managermodel.h \
+    Play/Danmu/Manager/nodeinfo.h \
+    Play/Danmu/Manager/pool.h \
+    Play/Danmu/Provider/localprovider.h \
+    Play/Danmu/Render/cacheworker.h \
+    Play/Danmu/Render/danmurender.h \
+    Play/Danmu/Render/livedanmuitemdelegate.h \
+    Play/Danmu/Render/livedanmulistmodel.h \
+    Play/Playlist/playlist.h \
+    Play/Playlist/playlistitem.h \
+    Play/Playlist/playlistprivate.h \
+    Play/Video/mpvplayer.h \
     Play/Video/mpvpreview.h \
     Play/Video/simpleplayer.h \
     Script/bgmcalendarscript.h \
@@ -250,29 +292,44 @@ HEADERS += \
     Script/scriptmanager.h \
     Script/scriptmodel.h \
     Script/scriptsettingmodel.h \
+    UI/about.h \
+    UI/adddanmu.h \
     UI/addpool.h \
     UI/addrule.h \
+    UI/adduritask.h \
     UI/animebatchaction.h \
     UI/animedetailinfopage.h \
     UI/animeinfoeditor.h \
     UI/animesearch.h \
     UI/autodownloadwindow.h \
+    UI/bgmlistwindow.h \
+    UI/blockeditor.h \
+    UI/capture.h \
+    UI/captureview.h \
     UI/charactereditor.h \
+    UI/checkupdate.h \
     UI/danmulaunch.h \
     UI/danmuview.h \
     UI/dlnadiscover.h \
+    UI/downloadwindow.h \
+    UI/framelessdialog.h \
+    UI/framelesswindow.h \
     UI/gifcapture.h \
     UI/inputdialog.h \
+    UI/librarywindow.h \
+    UI/list.h \
     UI/logwindow.h \
     UI/luatableviewer.h \
     UI/mainwindow.h \
-    UI/framelesswindow.h \
-    Play/Danmu/Layouts/bottomlayout.h \
-    Play/Danmu/Layouts/danmulayout.h \
-    Play/Danmu/Layouts/rolllayout.h \
-    Play/Danmu/Layouts/toplayout.h \
-    Play/Danmu/danmupool.h \
+    UI/matcheditor.h \
+    UI/mediainfo.h \
+    UI/player.h \
+    UI/pooleditor.h \
+    UI/poolmanager.h \
+    UI/ressearchwindow.h \
     UI/scriptplayground.h \
+    UI/selectepisode.h \
+    UI/selecttorrentfile.h \
     UI/settings.h \
     UI/settings/downloadpage.h \
     UI/settings/lanserverpage.h \
@@ -283,6 +340,8 @@ HEADERS += \
     UI/settings/stylepage.h \
     UI/snippetcapture.h \
     UI/stylemanager.h \
+    UI/timelineedit.h \
+    UI/tip.h \
     UI/widgets/backgroundfadewidget.h \
     UI/widgets/backgroundwidget.h \
     UI/widgets/clickslider.h \
@@ -290,71 +349,13 @@ HEADERS += \
     UI/widgets/colorslider.h \
     UI/widgets/danmustatiswidget.h \
     UI/widgets/dialogtip.h \
+    UI/widgets/dirselectwidget.h \
     UI/widgets/elidelineedit.h \
     UI/widgets/fonticonbutton.h \
     UI/widgets/loadingicon.h \
     UI/widgets/optionslider.h \
     UI/widgets/scriptsearchoptionpanel.h \
-    UI/widgets/smoothscrollbar.h \
-    globalobjects.h \
-    Play/Playlist/playlist.h \
-    Play/Video/mpvplayer.h \
-    UI/list.h \
-    UI/player.h \
-    UI/pooleditor.h \
-    UI/framelessdialog.h \
-    Play/Danmu/Provider/localprovider.h \
-    UI/adddanmu.h \
-    Play/Danmu/common.h \
-    UI/matcheditor.h \
-    UI/selectepisode.h \
-    Play/Danmu/blocker.h \
-    UI/blockeditor.h \
-    UI/capture.h \
-    UI/mediainfo.h \
-    UI/about.h \
-    Common/network.h \
-    Common/htmlparsersax.h \
-    MediaLibrary/animeinfo.h \
-    MediaLibrary/animeitemdelegate.h \
-    UI/librarywindow.h \
-    MediaLibrary/episodesmodel.h \
-    Download/util.h \
-    Download/aria2jsonrpc.h \
-    UI/widgets/dirselectwidget.h \
-    Download/downloaditemdelegate.h \
-    Download/downloadmodel.h \
-    Download/torrent.h \
-    UI/downloadwindow.h \
-    UI/adduritask.h \
-    UI/selecttorrentfile.h \
-    UI/poolmanager.h \
-    UI/checkupdate.h \
-    Common/zconf.h \
-    Common/zlib.h \
-    Common/flowlayout.h \
-    UI/timelineedit.h \
-    LANServer/lanserver.h \
-    Play/Playlist/playlistitem.h \
-    Play/Playlist/playlistprivate.h \
-    Play/Danmu/Render/cacheworker.h \
-    Play/Danmu/Render/danmurender.h \
-    Play/Danmu/Manager/danmumanager.h \
-    Play/Danmu/Manager/nodeinfo.h \
-    Play/Danmu/Manager/managermodel.h \
-    MediaLibrary/animeworker.h \
-    MediaLibrary/animemodel.h \
-    MediaLibrary/labelmodel.h \
-    MediaLibrary/animefilterproxymodel.h \
-    MediaLibrary/labelitemdelegate.h \
-    Download/BgmList/bgmlist.h \
-    UI/bgmlistwindow.h \
-    UI/ressearchwindow.h \
-    Play/Danmu/Manager/pool.h \
-    Common/threadtask.h \
-    MediaLibrary/capturelistmodel.h \
-    UI/captureview.h \
-    UI/tip.h
+    UI/widgets/smoothscrollbar.h
 
 INCLUDEPATH += \
     Play/Video \

--- a/kikoplay.desktop
+++ b/kikoplay.desktop
@@ -3,7 +3,7 @@ Type=Application
 Name=KikoPlay
 Comment=KikoPlay is a full-featured danmu player!
 TryExec=KikoPlay
-Exec=KikoPlay
+Exec=env QT_QPA_PLATFORM=xcb KikoPlay
 Icon=/usr/share/pixmaps/kikoplay.png
 Terminal=false
 StartupNotify=true


### PR DESCRIPTION
Optimized the build script, currently only the ones built by CMake can work normally under linux, and QT6 has switched to CMake by default. Optimized the build of CMake to facilitate future maintenance.

- Sort files for easy maintenance
- Now CMake will read source list from KikoPlay.pro file
- Automatically generate include paths