### PR TITLE
Screen awake for freedesktop environment/在freedecktop环境下阻止自动息屏

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,7 @@ if (WIN32)
 endif()
 
 if (UNIX)
+	find_package(Qt5 COMPONENTS DBus REQUIRED)
     # Set default overridable parameters for "/usr/share"
     set(CMAKE_INSTALL_SHAREDIR "/usr/share" CACHE STRING "The default share path")
     # Set default unix data option
@@ -113,6 +114,7 @@ if (UNIX)
     target_link_libraries(${PROJECT_NAME} 
     PRIVATE
         ${mpv_LIBRARIES}
+		Qt5::DBus
     )
 
     if (CONFIG_UNIX_DATA)

--- a/KikoPlay.pro
+++ b/KikoPlay.pro
@@ -5,6 +5,7 @@
 #-------------------------------------------------
 
 QT       += core gui sql network concurrent websockets
+linux:QT += dbus
 win32:QT += winextras
 
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets

--- a/UI/player.h
+++ b/UI/player.h
@@ -142,4 +142,7 @@ protected:
     virtual void wheelEvent(QWheelEvent *event) override;
 };
 
+void setAwakeRequired();
+void unsetAwakeRequired();
+
 #endif // PLAYERWINDOW_H


### PR DESCRIPTION
通过调用 `org.freedesktop.ScreenSaver` 的 D-Bus API，在观看视频时阻止屏保程序定时自动息屏。目前只在 Linux Gnome 下测试过，可能需要在 Windows 下测试以避免功能回归。

改动细则：

- 在 `KikoPlay.pro` 和 `CMakeLists.txt`中，为 Linux 目标添加了 Qt 模块 `dbus`。
- 在 `UI/player.h` 中，添加了函数 `setAwakeRequired()` 和 `unsetAwakeRequired()` 用于控制屏保。
- 在 `UI/player.cpp` 中，实现了 Linux 下的函数 `setAwakeRequired()` 和 `unsetAwakeRequired()`，并迁移了 Windows 下的实现。重构了 `QObject::connect(GlobalObjects::mpvplayer,&MPVPlayer::stateChanged)` 函数内的少量代码。

fixes #134
